### PR TITLE
Add LogWarning and LogVerbose and clean up some of the old unused things

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ set(azure_c_logging_c_files
 set(azure_c_logging_h_files
     ${LOGGING_H_FILE}
     ${LOGGING_STACKTRACE_H_FILE}
+    ./inc/azure_c_logging/xlogging.h
     )
 
 FILE(GLOB azure_c_logging_md_files "devdoc/*.md")

--- a/inc/azure_c_logging/etwlogger_driver.h
+++ b/inc/azure_c_logging/etwlogger_driver.h
@@ -10,10 +10,10 @@
 extern "C" {
 #endif /* __cplusplus */
 
-    extern void etwlogger_log(LOG_CATEGORY log_category, const char* file, const char* func, int line, unsigned int options, const char* format, ...);
+    void etwlogger_log(LOG_CATEGORY log_category, const char* file, const char* func, int line, unsigned int options, const char* format, ...);
 
 #if (defined(_MSC_VER))
-    extern void etwlogger_log_with_GetLastError(const char* file, const char* func, int line, const char* format, ...);
+    void etwlogger_log_with_GetLastError(const char* file, const char* func, int line, const char* format, ...);
 #endif
 
 #ifdef __cplusplus

--- a/src/consolelogger.c
+++ b/src/consolelogger.c
@@ -243,6 +243,12 @@ void consolelogger_log(LOG_CATEGORY log_category, const char* file, const char* 
     case AZ_LOG_INFO:
         (void)printf("Info: ");
         break;
+    case AZ_LOG_VERBOSE:
+        (void)printf("Verbose: ");
+        break;
+    case AZ_LOG_WARNING:
+        (void)printf("Warning: Time:%.24s File:%s Func:%s Line:%d ", ctime(&t), file, func, line);
+        break;
     case AZ_LOG_ERROR:
         (void)printf("Error: Time:%.24s File:%s Func:%s Line:%d ", ctime(&t), file, func, line);
         break;

--- a/src/xlogging.c
+++ b/src/xlogging.c
@@ -38,73 +38,6 @@ LOGGER_LOG_GETLASTERROR xlogging_get_log_function_GetLastError(void)
 }
 #endif
 
-/* Print up to 16 bytes per line. */
-#define LINE_SIZE 16
-
-/* Return the printable char for the provided value. */
-#define PRINTABLE(c)         ((c >= ' ') && (c <= '~')) ? (char)c : '.'
-
-/* Convert the lower nibble of the provided byte to a hexadecimal printable char. */
-#define HEX_STR(c)           (((c) & 0xF) < 0xA) ? (char)(((c) & 0xF) + '0') : (char)(((c) & 0xF) - 0xA + 'A')
-
-void LogBinary(const char* comment, const void* data, size_t size)
-{
-    char charBuf[LINE_SIZE + 1];
-    char hexBuf[LINE_SIZE * 3 + 1];
-    size_t countbuf = 0;
-    size_t i = 0;
-    const unsigned char* bufAsChar = (const unsigned char*)data;
-    const unsigned char* startPos = bufAsChar;
-
-    LOG(AZ_LOG_TRACE, LOG_LINE, "%s     %lu bytes", comment, (unsigned long)size);
-
-    /* Print the whole buffer. */
-    for (i = 0; i < size; i++)
-    {
-        /* Store the printable value of the char in the charBuf to print. */
-        charBuf[countbuf] = PRINTABLE(*bufAsChar);
-
-        /* Convert the high nibble to a printable hexadecimal value. */
-        hexBuf[countbuf * 3] = HEX_STR(*bufAsChar >> 4);
-
-        /* Convert the low nibble to a printable hexadecimal value. */
-        hexBuf[countbuf * 3 + 1] = HEX_STR(*bufAsChar);
-
-        hexBuf[countbuf * 3 + 2] = ' ';
-
-        countbuf++;
-        bufAsChar++;
-        /* If the line is full, print it to start another one. */
-        if (countbuf == LINE_SIZE)
-        {
-            charBuf[countbuf] = '\0';
-            hexBuf[countbuf * 3] = '\0';
-            LOG(AZ_LOG_TRACE, LOG_LINE, "%p: %s    %s", startPos, hexBuf, charBuf);
-            countbuf = 0;
-            startPos = bufAsChar;
-        }
-    }
-
-    /* If the last line does not fit the line size. */
-    if (countbuf > 0)
-    {
-        /* Close the charBuf string. */
-        charBuf[countbuf] = '\0';
-
-        /* Fill the hexBuf with spaces to keep the charBuf alignment. */
-        while ((countbuf++) < LINE_SIZE - 1)
-        {
-            hexBuf[countbuf * 3] = ' ';
-            hexBuf[countbuf * 3 + 1] = ' ';
-            hexBuf[countbuf * 3 + 2] = ' ';
-        }
-        hexBuf[countbuf * 3] = '\0';
-
-        /* Print the last line. */
-        LOG(AZ_LOG_TRACE, LOG_LINE, "%p: %s    %s", startPos, hexBuf, charBuf);
-    }
-}
-
 #ifdef WIN32
 
 void xlogging_LogErrorWinHTTPWithGetLastErrorAsStringFormatter(int errorMessageID)
@@ -140,6 +73,3 @@ void xlogging_LogErrorWinHTTPWithGetLastErrorAsStringFormatter(int errorMessageI
 
 
 #endif // NO_LOGGING
-
-
-

--- a/tests/logging_ut/minimal/minimal.c
+++ b/tests/logging_ut/minimal/minimal.c
@@ -7,10 +7,13 @@
 
 int main(void)
 {
-
     LogError("Hello World from LogError, here's a value: %d", 42);
 
+    LogWarning("Hello World from LogWarning, here's a value: %d", 4242);
+
     LogInfo("Hello World from LogInfo, here's a value: %d", 0x42);
+
+    LogVerbose("Hello World from LogVerbose, here's a value: %d", 0x4242);
 
     SetLastError(ERROR_ACCESS_DENIED);
 


### PR DESCRIPTION
Add LogWarning and LogVerbose and clean up some of the old unused things.
Note: there is a separate store for reworking the entire logging, but right now what I need is Warning and Verbose so we can split out logs in 4 categories.